### PR TITLE
Fix parameter copy ctor

### DIFF
--- a/include/lcfiplus.h
+++ b/include/lcfiplus.h
@@ -162,9 +162,10 @@ class Parameters {
   }
   // copy operator/constructor
   Parameters(const Parameters& ref)
-  : _map(ref._map)
+    : _map() //do not copy the map! shallow copy of pointers!
   , _allowstring(ref._allowstring)
   {
+    // calling assingment operator, which will do deep copy
     *this = ref;
   }
   Parameters& operator =(const Parameters& ref);  // in lcfiplus.cc

--- a/src/lcfiplus.cc
+++ b/src/lcfiplus.cc
@@ -1279,7 +1279,7 @@ vector<const Vertex*> Jet::getVerticesForFT() const {
 // under construction
 void Parameters::remove(const string& key, bool delmap) {
   if (_map.find(key) == _map.end())throw(Exception("Parameters::remove: key not found."));
-  else if (_map[key].first == &typeid(double))deleteData<double>(key);
+  else if (_map[key].first == &typeid(float))deleteData<float>(key);
   else if (_map[key].first == &typeid(double))deleteData<double>(key);
   else if (_map[key].first == &typeid(long))deleteData<long>(key);
   else if (_map[key].first == &typeid(int))deleteData<int>(key);

--- a/src/lcfiplus.cc
+++ b/src/lcfiplus.cc
@@ -1318,7 +1318,7 @@ Parameters& Parameters::operator =(const Parameters& ref) {
 
     // built-in types
     if (type == &typeid(double))add(key,*(double*)data);
-    else if (type == &typeid(double))add(key,*(double*)data);
+    else if (type == &typeid(float))add(key,*(float*)data);
     else if (type == &typeid(long))add(key,*(long*)data);
     else if (type == &typeid(int))add(key,*(int*)data);
     else if (type == &typeid(bool))add(key,*(bool*)data);


### PR DESCRIPTION
I think this fixes #19 

Edit: minimal changes now, only the map must _not_ be copied, because the assignment operator calls `clear`, which otherwise deletes the objects from the shallow copy, not a problem if the map is empty.

~~~I properly implemented the copy constructor for the parameters object because it gets copied and the instances of the parameters were deleted multiple times, because only a shallow copy was done.~~~

~~~I didn't implement the copy for arbitrary classes, because it wasn't used in the configuration I was testing with. Is this needed?~~~

Also fixed something in the `remove` and `clear` function were two times the double cases existed but never the float



BEGINRELEASENOTES
- lcfiplus::Parameters: fix implementation of the copy constructor, fixes lcfiplus/LCFIPlus#19 

ENDRELEASENOTES