### PR TITLE
[WIP/RFC] Fix issues if BeamspotConstraint is false

### DIFF
--- a/include/VertexFinderSuehara.h
+++ b/include/VertexFinderSuehara.h
@@ -126,7 +126,7 @@ void associateIPTracks(vector<Vertex*>& vertices, Vertex* ip, VertexFinderSuehar
 //using AVF method
 void associateIPTracksAVF(vector<Vertex*>& vertices, Vertex* ip, VertexFinderSueharaConfig& cfg);
 
-void buildUp(TrackVec& tracks, vector<Vertex*>& vtx, vector<Vertex*>& v0vtx, double chi2thpri, VertexFinderSueharaConfig& cfg, Vertex* ip = 0);
+void buildUp(TrackVec& tracks, vector<Vertex*>& vtx, vector<Vertex*>& v0vtx, double chi2thpri, VertexFinderSueharaConfig& cfg, Vertex** ip = 0);
 void buildUpForJetClustering(TrackVec& tracks, vector<Vertex*>& vtx);
 
 vector<Vertex*> makeSingleTrackVertices

--- a/src/LCIOStorer.cc
+++ b/src/LCIOStorer.cc
@@ -810,6 +810,7 @@ void LCIOStorer::WriteVertices(VertexVec* pvvtx, const char* newName, const char
   for (unsigned int n=0; n<pvvtx->size(); n++) {
     // set ID to the lcfiplus::Vertex
     const lcfiplus::Vertex* flavtx = (*pvvtx)[n];
+    if( not flavtx ) continue;
     flavtx->setId(n);
 
     // It seems that multiple entries in LCIO collection are not allowed: currently make independent entries

--- a/src/VertexFinderSuehara.cc
+++ b/src/VertexFinderSuehara.cc
@@ -882,7 +882,7 @@ void VertexFinderSuehara::associateIPTracksAVF(vector<Vertex *> &vertices, Verte
       if(loopiptracks.size()==0) loopiptracks.push_back(*it);
       else{
 	vector<const Track *>::iterator it3=loopiptracks.begin();
-	while(ip->getChi2Track(*it)<ip->getChi2Track(*it3) && it3 != loopiptracks.end()){
+	while(it3 != loopiptracks.end() && ip->getChi2Track(*it)<ip->getChi2Track(*it3) ){
 	  it3++;
 	}
 	if(it3 == loopiptracks.end()) loopiptracks.push_back(*it);

--- a/src/VertexFinderSuehara.cc
+++ b/src/VertexFinderSuehara.cc
@@ -1036,10 +1036,11 @@ void VertexFinderSuehara::associateIPTracksAVF(vector<Vertex *> &vertices, Verte
   return;
 }
 
-void VertexFinderSuehara::buildUp(TrackVec& tracks, vector<Vertex*>& vtx, vector<Vertex*>& v0vtx, double chi2thpri, VertexFinderSueharaConfig& cfg, Vertex* ip) {
+void VertexFinderSuehara::buildUp(TrackVec& tracks, vector<Vertex*>& vtx, vector<Vertex*>& v0vtx, double chi2thpri, VertexFinderSueharaConfig& cfg, Vertex** pIP) {
 
   // obtain primary vertex
   std::unique_ptr<Vertex> nip;
+  Vertex*& ip = *pIP;
   if (!ip) {
     ip = findPrimaryVertex(tracks, chi2thpri);
 //		vtx.push_back(ip);

--- a/src/VertexFinderSuehara.cc
+++ b/src/VertexFinderSuehara.cc
@@ -1039,12 +1039,12 @@ void VertexFinderSuehara::associateIPTracksAVF(vector<Vertex *> &vertices, Verte
 void VertexFinderSuehara::buildUp(TrackVec& tracks, vector<Vertex*>& vtx, vector<Vertex*>& v0vtx, double chi2thpri, VertexFinderSueharaConfig& cfg, Vertex* ip) {
 
   // obtain primary vertex
-  Vertex* nip = 0;
+  std::unique_ptr<Vertex> nip;
   if (!ip) {
     ip = findPrimaryVertex(tracks, chi2thpri);
 //		vtx.push_back(ip);
   } else {
-    nip = new Vertex(ip->getChi2(), ip->getProb(), ip->getX(), ip->getY(), ip->getZ(), ip->getCov(), true);
+    nip = std::unique_ptr<Vertex>(new Vertex(ip->getChi2(), ip->getProb(), ip->getX(), ip->getY(), ip->getZ(), ip->getCov(), true));
 //		vtx.push_back(nip);
   }
 

--- a/src/lcfiplus.cc
+++ b/src/lcfiplus.cc
@@ -85,8 +85,12 @@ const Vertex* Event::getPrimaryVertex(const char* privtxname) const {
   const char* classname = "vector<lcfiplus::Vertex*>";
 
 //		if(!IsExist(privtxname,classname))throw(Exception("Event::getPrimaryVertex(): collection not found."));
-
-  return (*(vector<const lcfiplus::Vertex*>*)GetObject(privtxname,classname))[0];
+  auto const& primaryVertices = (*(vector<const lcfiplus::Vertex*>*)GetObject(privtxname,classname));
+  if(primaryVertices.size() > 0 ){
+    return primaryVertices[0];
+  } else {
+    return nullptr;
+  }
 }
 
 const vector<const Vertex*>& Event::getSecondaryVertices(const char* secvtxname) const {

--- a/src/process.cc
+++ b/src/process.cc
@@ -158,10 +158,15 @@ void BuildUpVertex::process() {
   Vertex* primvtx;
 
   try {
-    primvtx = new Vertex(*event->getPrimaryVertex(_primvtxcolname.c_str()));
+    const Vertex *primVertex = event->getPrimaryVertex(_primvtxcolname.c_str());
+    if (primVertex) {
+      primvtx = new Vertex(*primVertex);
+    } else {
+      throw lcfiplus::Exception("No primary Vertex");
+    }
   } catch (lcfiplus::Exception& e) {
     cout << "BuildUpVertex::process(): primary vertex not found - invoking primary vertex finder internally." << endl;
-    primvtx = 0;
+    primvtx = nullptr;
   }
 
   VertexFinderSuehara::VertexFinderSueharaConfig cfg;


### PR DESCRIPTION
Addresses some issues from #22 and a few memory issues (access, memory leaks)

Todo: 

- [ ] @nachogargar is currently testing

comments are already welcome

- [ ] Please tell me there is a better way to store the on-the-fly created vertex in the existing collection and replacing the nullptr Vertex inside the first entry, instead of doing  `const_cast` (https://github.com/lcfiplus/LCFIPlus/compare/master...andresailer:primVtx?expand=1#diff-d5939a2753951ddbb81d7c60554d505cR195)  .


BEGINRELEASENOTES
- Fix crash when BeamspotContraint is false
- Fix memory leak in VertexFinderSuehara

ENDRELEASENOTES