### PR TITLE
LcfiPlusProcessor: processorParameters are now a shared_ptr

### DIFF
--- a/src/LcfiplusProcessor.cc
+++ b/src/LcfiplusProcessor.cc
@@ -90,7 +90,7 @@ void LcfiplusProcessor::init() {
     // usually a good idea to
     printParameters() ;
 
-    StringParameters* parameter = parameters();
+    std::shared_ptr<StringParameters> parameter = parameters();
     /*
     		// obtain algorithm name
     		if(!parameter->isParameterSet("algorithm")){


### PR DESCRIPTION
As of ilcsoft/Marlin#16 the returned objects are now `shared_ptr`s

BEGINRELEASENOTES
- Processor parameters are now a shared_ptr

ENDRELEASENOTES