### PR TITLE
Adding -std=c++11 to build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ ENDIF()
 INCLUDE_DIRECTORIES( "./include" )
 
 # definitions to pass to the compiler
-ADD_DEFINITIONS( "-Wno-effc++ -Wno-shadow" )
+ADD_DEFINITIONS( "-Wno-effc++ -Wno-shadow -std=c++11" )
 ADD_DEFINITIONS( "-Wno-long-long" )
 ADD_DEFINITIONS( "-Wno-strict-aliasing" ) # avoid warnings in dict.cc
 # shut up warnings in boost


### PR DESCRIPTION

BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES