### PR TITLE
Valencia Jet Algorithm updated definition on JetClustering

### DIFF
--- a/include/JetFinder.h
+++ b/include/JetFinder.h
@@ -21,6 +21,7 @@ struct JetConfig {
   double rParameter;     // for Kt
   double alphaParameter; // for Durham
   double betaParameter;  // for Valencia
+  double gammaParameter;  // for Valencia
   double coneR;
   double epsCut;
   string coreAlgo;
@@ -46,6 +47,7 @@ struct JetConfig {
       rParameter(1.0),
       alphaParameter(1.0),
       betaParameter(1.0),
+      gammaParameter(1.0),
       coneR(0),
       epsCut(0), 
       coreThreshold(0),

--- a/include/process.h
+++ b/include/process.h
@@ -96,6 +96,7 @@ class JetClustering : public Algorithm {
   double _rParameter;
   double _alphaParameter;
   double _betaParameter;
+  double _gammaParameter;
   bool _useMuonID;
   bool _muonIDExternal;
   double _muonIDMinEnergy;

--- a/src/JetFinder.cc
+++ b/src/JetFinder.cc
@@ -52,7 +52,6 @@ double JetFinder::funcValencia(Jet& jet1, Jet& jet2, double /*Evis2*/, JetConfig
 
   double R_param = cfg.rParameter;
   double beta = cfg.betaParameter;
-  double gamma = cfg.gammaParameter;
 
   double e1 = jet1.E();
   double e2 = jet2.E();

--- a/src/JetFinder.cc
+++ b/src/JetFinder.cc
@@ -48,16 +48,17 @@ double JetFinder::funcKt(Jet& jet1, Jet& jet2, double /*Evis2*/, JetConfig& cfg)
 
 }
 double JetFinder::funcValencia(Jet& jet1, Jet& jet2, double /*Evis2*/, JetConfig& cfg) {
-  // d_ij = min(Ei^2, Ej^2 )(1 - cos(theta_ij))/R^2
+  // d_ij = 2min(Ei^2, Ej^2 )(1 - cos(theta_ij))/R^2
 
   double R_param = cfg.rParameter;
   double beta = cfg.betaParameter;
+  double gamma = cfg.gammaParameter;
 
   double e1 = jet1.E();
   double e2 = jet2.E();
   TVector3 mom1 = jet1.Vect();
   TVector3 mom2 = jet2.Vect();
-  double val = min(pow(e1, 2.*beta),pow(e2, 2.*beta))*max(0., 1-(mom1.Dot(mom2))/(mom1.Mag()*mom2.Mag())) / pow(R_param,2.);
+  double val = 2*min(pow(e1, 2.*beta),pow(e2, 2.*beta))*max(0., 1-(mom1.Dot(mom2))/(mom1.Mag()*mom2.Mag())) / pow(R_param,2.);
   return val;
 }
 
@@ -116,7 +117,8 @@ double JetFinder::funcKtBeamDistance(Jet& jet1, double /*Evis2*/, JetConfig& /*c
 }
 
 double JetFinder::funcValenciaBeamDistance(Jet& jet1, double /*Evis2*/, JetConfig& cfg) {
-  return pow(jet1.Pt(), 2. * cfg.betaParameter);
+  // d_iB = Ei^2beta*sin(theta_iB)^2gamma
+  return pow(jet1.E(), 2. * cfg.betaParameter)*pow(jet1.Pt()/jet1.E(), 2. * cfg.gammaParameter);
 }
 
 double JetFinder::funcDurhamCheat(Jet& jet1, Jet& jet2, double Evis2, JetConfig& /*cfg*/) {

--- a/src/process.cc
+++ b/src/process.cc
@@ -235,6 +235,7 @@ void JetClustering::init(Parameters* param) {
   _rParameter = param->get("JetClustering.RParameter", double(1.0));
   _alphaParameter = param->get("JetClustering.AlphaParameter", double(1.0));
   _betaParameter = param->get("JetClustering.BetaParameter", double(1.0));
+  _gammaParameter = param->get("JetClustering.GammaParameter", double(1.0));
   _outputVertexStoresVertex = param->get("JetClustering.OutputJetStoresVertex",int(0));
 
   // checks
@@ -326,6 +327,7 @@ void JetClustering::process() {
   jetCfg.rParameter = _rParameter;
   jetCfg.alphaParameter = _alphaParameter;
   jetCfg.betaParameter = _betaParameter;
+  jetCfg.gammaParameter = _gammaParameter;
   jetCfg.YaddVV = _yaddVV;
   jetCfg.YaddVL = _yaddVL;
   jetCfg.YaddLL = _yaddLL;


### PR DESCRIPTION
Valencia jet algorithm as implemented within LCFIPlus in JetFinder.cc is outdated. 
It has been improved since its first release to the public.
It should be changed to the last definition found in the contrib of FastJet
http://fastjet.hepforge.org/svn/contrib/contribs/ValenciaPlugin/tags/2.0.0/

## Changes in this fork:

**1.** Adding a missing factor 2 in the inter-particle distance definition -> **d_ij = 2min(Ei^2, Ej^2 )(1 - cos(theta_ij))/R^2**

**2.** Particle-to-beam distance modified to -> **d_iB = Ei^2beta*sin(theta_iB)^2gamma**
as found in http://cds.cern.ch/record/2270264/files/CLICdp-Pub-2017-002.pdf

**3.** Added the second extra parameter **gamma** to jet configuration (jetCfg.gammaParameter = _gammaParameter;)

**I have personally checked that everything works properly after those changes**

If someone else wants to do a crosscheck, I might provide the code for that.

