### PR TITLE
Add TrackHitOrdering for CLIC detector

### DIFF
--- a/src/LCIOStorer.cc
+++ b/src/LCIOStorer.cc
@@ -526,6 +526,17 @@ void LCIOStorer::SetEvent(lcio::LCEvent* evt) {
           for (int i=0; i<lcfiplus::tpar::hitN; ++i) {
             nhits[i] = trk->getSubdetectorHitNumbers()[i];
           }
+        } else if (_trackHitOrdering == 2) {
+          // CLICdet format
+          const vector<int>& vec = trk->getSubdetectorHitNumbers();
+          int offset = 2; // 2=fit, 1=patrec
+          nhits[tpar::VTX] = vec[2 * 1 - offset]; // vtx barrel
+          nhits[tpar::FTD] = vec[2 * 2 - offset]; // vtx endcap
+          nhits[tpar::SIT] = 0;
+          // inner barrel and endcap, and outer barrel and endcap
+          nhits[tpar::TPC] = vec[2 * 3 - offset] + vec[2 * 4 - offset] + vec[2 * 5 - offset] + vec[2 * 6 - offset];
+          nhits[tpar::SET] = 0;
+          nhits[tpar::ETD] = 0;
         } else {
           // ILD DBD format
           const vector<int>& vec = trk->getSubdetectorHitNumbers();

--- a/src/LcfiplusProcessor.cc
+++ b/src/LcfiplusProcessor.cc
@@ -47,7 +47,7 @@ LcfiplusProcessor::LcfiplusProcessor() : Processor("LcfiplusProcessor") {
 
   registerProcessorParameter("Algorithms", "LCFIPlus algorithms to run", _algonames, vector<string>());
   registerProcessorParameter("ReadSubdetectorEnergies", "Read subdetector energies (ILD)", _readSubdetectorEnergies, int(1));
-  registerProcessorParameter("TrackHitOrdering", "Track hit ordering: 0=ILD-LOI (default), 1=ILD-DBD", _trackHitOrdering, int(0));
+  registerProcessorParameter("TrackHitOrdering", "Track hit ordering: 0=ILD-LOI (default), 1=ILD-DBD, 2=CLICdet", _trackHitOrdering, int(0));
   registerProcessorParameter("UpdateVertexRPDaughters", "Writing back obtained vertices to input RP collections (which must be writable)",
                              _updateVertexRPDaughters, int(1));
   registerProcessorParameter("IgnoreLackOfVertexRP", "Keep running even if vertex RP collection is not present",


### PR DESCRIPTION
As the sub-detectors in our new CLIC detector do not correspond to the ILD subdetectors (we don't have a tpc, but we have a vtx endcap, etc.) we need a different hitordering scheme.

BEGINRELEASENOTES
- Add TrackHitOrdering=2 for LCFIPlusProcessor which conforms to the CLIC detector

ENDRELEASENOTES