### PR TITLE
Add daughter relation in lcfiplus::MCPartilce.

### DIFF
--- a/src/LCIOStorer.cc
+++ b/src/LCIOStorer.cc
@@ -342,6 +342,7 @@ void LCIOStorer::SetEvent(lcio::LCEvent* evt) {
 
       lcfiplus::MCParticle *mcpNew = _mcpLCIORel2[mcp];
       mcpNew->setParent(parent);
+      if (parent) parent->addDaughter(mcpNew);   
 
       // add daughters to other MCPs
       if (mcp->getParents().size()>1) {


### PR DESCRIPTION

BEGINRELEASENOTES
Add daughter relation in lcfiplus::MCPartilce. This change does not affect usual reconstruction where no MCParticle is used.
ENDRELEASENOTES