### PR TITLE
Cope with events having no vertex track candidates.

### DIFF
--- a/src/process.cc
+++ b/src/process.cc
@@ -79,7 +79,8 @@ void PrimaryVertexFinder::process() {
 
   // primary vertex finder
   Vertex* vtx = findPrimaryVertex(passedTracks,_chi2th,_beamspotConstraint,_beamspotSmearing);
-  _vertex->push_back(vtx);
+  if (vtx) _vertex->push_back(vtx);
+  else cout << "PrimaryVertexFinder: No primary vertex found." << endl; 
   if (verbose)
     cout << "PrimaryVertexFinder: " << vtx->getTracks().size() << " tracks associated to the primary vertex." << endl;
 }


### PR DESCRIPTION

BEGINRELEASENOTES
Cope with events having no vertex track candidates.
- It tried to add a vertex even if it is a null pointer. This is confusing and caused a problem later processes in some cases.
ENDRELEASENOTES