### PR TITLE
This fixs a problem when using an external jet collection. 

### DIFF
--- a/include/LCIOStorer.h
+++ b/include/LCIOStorer.h
@@ -36,7 +36,7 @@ class LCIOStorer : public TObject, public EventStoreObserver {
 
   // initialize misc collections
   void InitVertexCollection(const char* lcioName, const char* flavtagName, bool readnow = true);
-  void InitJetCollection(const char* lcioName, const char* flavtagName, bool readnow = true, bool readvtx = true, const char* vtxname = 0);
+  void InitJetCollection(const char* lcioName, const char* flavtagName, bool readnow = true, bool readvtx = false, const char* vtxname = 0);
 
   /*
   			// register every LCIO collections: used only in standalone


### PR DESCRIPTION
It required an external vertex collection whose name is the jet collection name with the suffix of "_vtx", which can not be changed from configuration file. Such vertex collection is not necessarily needed.

BEGINRELEASENOTES
- Fix a problem when using an external jet collection (e.g. FastJet and no LCFIPlus jet clustering).
- It required an external vertex collection named "JET COLLECTION NAME" + "_vtx" when using an external jet collection(e.g. output of FastJet).  Such a new vertex collection is not necessarily needed.
- Changed a default behaivour so that it will not require such an external vertex collection.

ENDRELEASENOTES