### PR TITLE
Remove some memory leaks

### DIFF
--- a/include/VertexFitterSimple.h
+++ b/include/VertexFitterSimple.h
@@ -19,9 +19,9 @@ class VertexFitterSimple {
 
     GeometryHandler* gh = GeometryHandler::Instance();
     if (pointConstraint) {
-      Point* ip = new Point(pointConstraint,PointBase::PRIVTX);
       vector<PointBase*> tracks;
       if (!pointInitialOnly) {
+        Point* ip = new Point(pointConstraint,PointBase::PRIVTX);
         tracks.push_back(ip);
       }
       int ntracks = 0;

--- a/src/LCIOStorer.cc
+++ b/src/LCIOStorer.cc
@@ -362,7 +362,7 @@ void LCIOStorer::SetEvent(lcio::LCEvent* evt) {
   for (itPfoCol = _importPFOCols.begin(); itPfoCol != _importPFOCols.end(); itPfoCol ++) {
 
     LCCollection* colPFO = evt->getCollection(itPfoCol->first);
-    PIDHandler *PID = new PIDHandler(evt->getCollection(itPfoCol->first)); 
+    PIDHandler PID(evt->getCollection(itPfoCol->first));
 
     // looking for LCRelation
     vector<lcio::LCRelationNavigator*> navs;
@@ -441,17 +441,17 @@ void LCIOStorer::SetEvent(lcio::LCEvent* evt) {
 
 	//PIDs
 	try{
-	  int pidAlgoID = PID->getAlgorithmID(_pidAlgoName);
+	  int pidAlgoID = PID.getAlgorithmID(_pidAlgoName);
 	  //pdg value
-	  track->setPDG(PID->getParticleID(pfo,pidAlgoID).getPDG());
+	  track->setPDG(PID.getParticleID(pfo,pidAlgoID).getPDG());
 	  //posterior probabilities for each particle type hypothesis
-	  int vecsize = PID->getParticleID(pfo,pidAlgoID).getParameters().size();
+	  int vecsize = PID.getParticleID(pfo,pidAlgoID).getParameters().size();
 	  for(int i=0;i<vecsize;i++) 
-	    track->setParticleIDProbability(PID->getParameterNames(pidAlgoID)[i],
-					    (double)PID->getParticleID(pfo,pidAlgoID).getParameters()[i]);	
+	    track->setParticleIDProbability(PID.getParameterNames(pidAlgoID)[i],
+					    (double)PID.getParticleID(pfo,pidAlgoID).getParameters()[i]);
 
 	  //cal. corrected mass
-	  track->setCorrEnergy(pmass[PID->getParticleID(pfo,pidAlgoID).getPDG()]);
+	  track->setCorrEnergy(pmass[PID.getParticleID(pfo,pidAlgoID).getPDG()]);
 	  //track->swapEnergy();  //really temporal need flag...
 	}catch(UTIL::UnknownAlgorithm e){
 	}

--- a/src/LcfiplusProcessor.cc
+++ b/src/LcfiplusProcessor.cc
@@ -274,7 +274,9 @@ void LcfiplusProcessor::end() {
 
   for (unsigned int i=0; i<_algos.size(); i++) {
     _algos[i]->end();
+    delete _algos[i];
   }
+  _algos.clear();
 
   Event::Instance()->ClearObjects();
 
@@ -282,6 +284,7 @@ void LcfiplusProcessor::end() {
             << " processed " << _nEvt << " events in " << _nRun << " runs "
             << std::endl ;
 
+  delete _param;
 }
 
 void LcfiplusProcessor::RegisterCallback(const char* name, const char* classname, int flags) {

--- a/src/VertexFinderSuehara.cc
+++ b/src/VertexFinderSuehara.cc
@@ -895,15 +895,9 @@ void VertexFinderSuehara::associateIPTracksAVF(vector<Vertex *> &vertices, Verte
       //get ip chisquare of this track                                                                                                          
       double chi2ip = ip->getChi2Track(*it);
 
-
-      double *chi2s= new double[vertices.size()];
-      double *maxchi2s= new double[vertices.size()];
-
       //initialize                                                                                                                              
-      for(unsigned int i=0;i<vertices.size();i++){
-	chi2s[i]=1.0e+10;
-	maxchi2s[i]=0.0;
-      }
+      std::vector<double> chi2s(vertices.size(), 1.0e+10);
+      std::vector<double> maxchi2s(vertices.size(), 0.0);
 
       for(unsigned int i=0;i<vertices.size();i++){    //loop over vertices                                                                      
 	//vertex quality cut                                                                                                                    
@@ -1015,8 +1009,6 @@ void VertexFinderSuehara::associateIPTracksAVF(vector<Vertex *> &vertices, Verte
     
       lflg=false;
 
-      delete chi2s;
-      delete maxchi2s;
     }
 
     if(iptracks.size() < ip->getTracks().size()){

--- a/src/process.cc
+++ b/src/process.cc
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <string>
+#include <memory>
 
 #include "EventStore.h"
 #include "TrackSelector.h"
@@ -345,7 +346,7 @@ void JetClustering::process() {
   // obtain jetvertices
   const Vertex* ip = event->getPrimaryVertex(_vpricolname.c_str());
 
-  JetFinder* jetFinder = new JetFinder(jetCfg,ip);
+  std::shared_ptr<JetFinder> jetFinder = std::make_shared<JetFinder>(jetCfg,ip);
 
   std::vector<double> ymin(_maxYth, 0.0);
 

--- a/src/process.cc
+++ b/src/process.cc
@@ -347,8 +347,7 @@ void JetClustering::process() {
 
   JetFinder* jetFinder = new JetFinder(jetCfg,ip);
 
-  double* ymin = new double[_maxYth];
-  memset(ymin, 0, sizeof(double) * _maxYth);
+  std::vector<double> ymin(_maxYth, 0.0);
 
   // select vertices
   vector<const Vertex*> selectedVertices;
@@ -387,7 +386,7 @@ void JetClustering::process() {
       }
 
       vector<Jet*>& jets = *(_jetsmap[_njets[n]]);
-      jets = jetFinder->run(curjets, ymin, _maxYth);
+      jets = jetFinder->run(curjets, &ymin[0], _maxYth);
       curjets.clear();
 
       // copy jets to curjets
@@ -418,7 +417,7 @@ void JetClustering::process() {
       jetFinder->Configure(jetCfg);
 
       vector<Jet*>& jets = *(_jetsmap[_ycut[n]]);
-      jets = jetFinder->run(curjets, ymin, _maxYth);
+      jets = jetFinder->run(curjets, &ymin[0], _maxYth);
       curjets.clear();
 
       // copy jets to curjets
@@ -454,7 +453,7 @@ void JetClustering::process() {
   jetCfg.Ycut = 0;
   jetFinder->Configure(jetCfg);
 
-  vector<Jet*> jets = jetFinder->run(curjets, ymin, _maxYth);
+  vector<Jet*> jets = jetFinder->run(curjets, &ymin[0], _maxYth);
   // delete jets
   for (unsigned int i=0; i<jets.size(); i++)
     delete jets[i];


### PR DESCRIPTION
This fixes a number of memory leaks we observe in our tests.

BEGINRELEASENOTES
- LCIOStorer: fix memory leak of PIDHandler
- LCFIPlusProcessor: clean algos and params after the end() of algos, fix memory leaks
- Process: fix memory leak of `double *ymin`, use `std::vector<double>`
- Process: use shared_ptr for JetFinder, fixes memory leak
- VertexFitterSimple: fix memory leak for IP: only create it if it is used
- VertexFinderSuehara: fix mismatch between new[] and delete (w/o []), use std::vector<double>

ENDRELEASENOTES