### PR TITLE
JetFinder fix: avoid double counting tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ You should have received a copy of the GNU General Public License long with this
 
 see: [./doc/ReleaseNotes.md](./doc/ReleaseNotes.md)
 
+Primary Vertices are built out of Tracks, then secondary vertices are found, in a further step vertices and jets are matched to each other to find classification probabilities that the jet originates from a b-quark, or a c-quark, or a light flavor quark
 
 JetFinderFix Version of the code evaluates methods which mix slightly different input collection for vertexing and jet clustering. The original code expected the inputs to be the same, thus it had to be modified to avoid double counting of inputs.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ You should have received a copy of the GNU General Public License long with this
 ## Release notes
 
 see: [./doc/ReleaseNotes.md](./doc/ReleaseNotes.md)
+
+
+JetFinderFix Version of the code evaluates methods which mix slightly different input collection for vertexing and jet clustering. The original code expected the inputs to be the same, thus it had to be modified to avoid double counting of inputs.

--- a/src/JetFinder.cc
+++ b/src/JetFinder.cc
@@ -367,7 +367,19 @@ vector<Jet*> JetFinder::prerun(TrackVec& tracks, NeutralVec& neutrals, VertexVec
     }
 
     if (jetToAssoc) {
-      jetToAssoc->add(tracks[i]);
+      bool veto_track=false;
+      for (unsigned int k=0; k<jetToAssoc->getVertices().size(); k++) {
+	const Vertex* vtx = jetToAssoc->getVertices()[k];
+	for (unsigned int n=0;n<vtx->getTracks().size();n++){
+	  if(vtx->getTracks()[n]->Angle(tracks[i]->Vect())==0){
+	    veto_track=true;
+	    break;
+	  }
+	}
+      }
+      if(!veto_track){
+	jetToAssoc->add(tracks[i]);
+      }
       usedTracks[i] = true;
     }
   }

--- a/src/JetFinder.cc
+++ b/src/JetFinder.cc
@@ -371,7 +371,7 @@ vector<Jet*> JetFinder::prerun(TrackVec& tracks, NeutralVec& neutrals, VertexVec
       for (unsigned int k=0; k<jetToAssoc->getVertices().size(); k++) {
 	const Vertex* vtx = jetToAssoc->getVertices()[k];
 	for (unsigned int n=0;n<vtx->getTracks().size();n++){
-	  if(vtx->getTracks()[n]->Angle(tracks[i]->Vect())==0){
+	  if(vtx->getTracks()[n]->Angle(tracks[i]->Vect())<1.e-6 && (vtx->getTracks()[n]->E()-tracks[i]->E())<1.e-6){
 	    veto_track=true;
 	    break;
 	  }


### PR DESCRIPTION
BEGINRELEASENOTES
LCFIPLUS JetFinder
- new procedure avoids adding tracks originating from a vertex to a jet twice
- if a track is very close to a vertex, check if track already part of the vertex jet before adding it to the jet
ENDRELEASENOTES