### PR TITLE
Filter `RefinedVertex` from being attached via the `PIDHandler`

### DIFF
--- a/include/LCIOStorer.h
+++ b/include/LCIOStorer.h
@@ -140,6 +140,8 @@ class LCIOStorer : public TObject, public EventStoreObserver {
   bool _ignoreLackOfVertexRP;
   string _pidAlgoName;
 
+  std::vector<std::string> m_filterPIDAlgos{{"RefinedVertex"}};
+
   ClassDef(LCIOStorer,0);
 };
 

--- a/src/LCIOStorer.cc
+++ b/src/LCIOStorer.cc
@@ -1093,6 +1093,9 @@ void LCIOStorer::WriteAllPIDs(lcio::LCCollection* lciocol, lcio::ReconstructedPa
 
   map<string, Parameters>::const_iterator it;
   for (it = parammap.begin(); it != parammap.end(); it++) {
+    if (std::find(m_filterPIDAlgos.begin(), m_filterPIDAlgos.end(), it->first) != m_filterPIDAlgos.end()) {
+      continue;
+    }
     WritePID(lciocol, lciojet, lcfijet, it->first.c_str());
   }
 

--- a/src/LCIOStorer.cc
+++ b/src/LCIOStorer.cc
@@ -453,7 +453,7 @@ void LCIOStorer::SetEvent(lcio::LCEvent* evt) {
 	  //cal. corrected mass
 	  track->setCorrEnergy(pmass[PID.getParticleID(pfo,pidAlgoID).getPDG()]);
 	  //track->swapEnergy();  //really temporal need flag...
-	}catch(UTIL::UnknownAlgorithm e){
+	}catch(UTIL::UnknownAlgorithm& e){
 	}
 	
 	//tempolary


### PR DESCRIPTION

BEGINRELEASENOTES
- Filter the `RefinedVertex` information from being attached to Jets via the `PIDHandler`.

ENDRELEASENOTES

This seems to be mainly used as an internal caching mechanism for the vertex fit probability. See #69 for a rationale for this. This does not yet fully solve #69, but it addresses one part of it.