### PR TITLE
Update Key4hep based CI to use existing nightlies

### DIFF
--- a/.github/workflows/key4hep-build.yml
+++ b/.github/workflows/key4hep-build.yml
@@ -2,15 +2,14 @@
 # The template file can be found in
 # https://github.com/key4hep/key4hep-actions/blob/main/workflows/key4hep-build.yaml
 name: Key4hep build
-
 on:
   push:
     branches:
-    - main
+      - master
   pull_request:
   workflow_dispatch:
   schedule:
-        - cron: '16 5 * * *'
+    - cron: 16 4 * * 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,7 +20,12 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22"]
+        image: ["alma9"]
+        stack: ["key4hep"]
+        include:
+          - build_type: nightly
+            image: ubuntu24
+            stack: key4hep
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -30,3 +34,4 @@ jobs:
       with:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
+        stack: ${{ matrix.stack }}


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure to run Key4hep based CI on existing nightlies

ENDRELEASENOTES